### PR TITLE
Improve strategy using Bollinger breakout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Variables principales
+BINANCE_API_KEY=tu_clave
+BINANCE_API_SECRET=tu_secreto
+
+TELEGRAM_BOT_TOKEN=token_telegram
+TELEGRAM_CHAT_ID=tu_chat_id
+
+# Opcional: claves adicionales para signals.py
+#BINANCE_API_KEY_CUENTA1_spot=...
+#BINANCE_API_SECRET_CUENTA1_spot=...

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# codigo_com
+# Codigo Com
+
+Bot asincrónico para trading spot en Binance.  Utiliza una estrategia en varias fases:
+
+1. **Fase 1** detecta rupturas de la banda superior de Bollinger con volumen elevado y marca los símbolos como precandidatos.
+2. **Fase 2** espera un pullback a la zona entre esa banda y la EMA(9), compra tras el rebote y gestiona la posición con trailing ATR, Δ‑stop y stop absoluto.
+3. **Fase 3** repone candidatos cuando hay huecos disponibles.
+4. **Sync** mantiene el estado real de las posiciones y aplica stops en modo
+   liviano cuando se opera desde otro dispositivo.
+
+Las notificaciones se envían a Telegram y todas las llamadas a la API de Binance
+están limitadas para evitar bloqueos.
+
+El bot mantiene un sistema de **caché con TTL** para el listado de pares y los
+históricos de precios, reduciendo el tráfico hacia Binance. Las notificaciones
+al chat se centralizan mediante `send_telegram_message` con control antiflood.
+
+## Características principales
+
+- Estrategia de ruptura con Bollinger Bands y confirmación de volumen.
+- Gestión de posiciones con EMA(9), trailing ATR y stops dinámicos.
+- Sincronización periódica de balances para detectar operaciones externas.
+- Comandos de Telegram para ajustar parámetros en caliente.
+
+## Uso rápido
+
+1. Copia `.env.example` a `.env` y completa tus claves.
+2. Instala dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Ejecuta `./run_bot.sh` para iniciar el bot en un bucle de reinicio
+automático.
+
+Los parámetros pueden modificarse en caliente a través de comandos de Telegram
+(`/set`, `/add`, `/elimina`, `/pausa`, etc.).
+
+## Variables de entorno
+
+Se requieren al menos las siguientes variables:
+
+- `BINANCE_API_KEY` y `BINANCE_API_SECRET`
+- `TELEGRAM_BOT_TOKEN` y `TELEGRAM_CHAT_ID`
+
+Opcionalmente pueden definirse claves adicionales para `signals.py` con el
+prefijo `BINANCE_API_KEY_<CUENTA>_spot`.
+
+Consulta `.env.example` para ver todas las variables necesarias.
+
+## Licencia
+
+MIT

--- a/config.py
+++ b/config.py
@@ -40,6 +40,8 @@ MIN_SYNC_USDT            = 10.0
 TRAILING_USDT            = 2.0            # colchón ATR
 STOP_DELTA_USDT          = 1.0            # trailing dinámico (máx-price−Δ)
 STOP_ABS_USDT            = 18.0           # stop absoluto en valor
+STOP_ABS_HIGH_FACTOR     = 51.0           # stop por cantidad si precio alto
+STOP_ABS_HIGH_THRESHOLD  = 55.0           # umbral de precio alto USDT
 # modo liviano
 LIGHT_MODE               = True          # True → Fase2 sólo entradas
 # ciclo y slots

--- a/signals.py
+++ b/signals.py
@@ -7,7 +7,7 @@ import logging
 from binance.client import Client
 from binance.enums import SIDE_BUY, SIDE_SELL, ORDER_TYPE_MARKET
 from dotenv import load_dotenv
-from telegram import Bot
+from utils import send_telegram_message
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -18,16 +18,6 @@ logging.basicConfig(
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
-telegram_bot = Bot(token=TELEGRAM_TOKEN)
-
-async def send_telegram_message(message: str):
-    try:
-        await telegram_bot.send_message(chat_id=TELEGRAM_CHAT_ID, text=message)
-        logger.info(f"Mensaje enviado a Telegram: {message}")
-    except Exception as e:
-        logger.error(f"Error al enviar mensaje por Telegram: {e}")
-    finally:
-        await asyncio.sleep(2.0)
 
 async def comprar_criptomoneda(account_name: str, symbol: str) -> dict:
     """Orden de compra Spot usando quoteOrderQty."""


### PR DESCRIPTION
## Summary
- replace near-cross logic with Bollinger breakout criteria
- wait for pullback to EMA9 to enter
- exit when price closes below EMA9
- document new strategy in README and mention TTL caching
- provide Bollinger bands helper

## Testing
- `python -m py_compile utils.py fases/fase1.py fases/fase2.py fases/fase3.py fases/position_sync.py config.py telegram_commands.py signals.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b43c5f604832a8418f875b4fda30a