### PR TITLE
Implement breakout pullback strategy

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ CVD_MIN          = 0
 # ───── K-line intervalos ────────────────────────────────────────────
 KLINE_INTERVAL_FASE0 = Client.KLINE_INTERVAL_15MINUTE
 KLINE_INTERVAL_FASE1 = Client.KLINE_INTERVAL_4HOUR
-KLINE_INTERVAL_FASE2 = Client.KLINE_INTERVAL_30MINUTE
+KLINE_INTERVAL_FASE2 = Client.KLINE_INTERVAL_4HOUR
 # ─────────────────────────────────────────────────────────────
 #  Ajustes DINÁMICOS (modificables vía Telegram) – Fase 0 y tamaño entrada
 # ─────────────────────────────────────────────────────────────

--- a/fases/fase1.py
+++ b/fases/fase1.py
@@ -1,128 +1,77 @@
+"""Fase 1 – escáner continuo de rupturas.
 
-"""Fase 1 – Búsqueda de precandidatos.
-
-Escanea todos los pares USDT en busca de cruces inminentes HMA‑8 por debajo de
-EMA‑24 en el marco de 30 minutos.  Los símbolos válidos se marcan como
-``RESERVADA_PRE`` para que otras fases los vigilen.
+Revisa de forma periódica todos los pares USDT en busca de
+cierres por encima de la banda superior de Bollinger con
+volumen elevado y RSI positivo.  Los símbolos que cumplan
+los requisitos se marcan como ``RESERVADA_PRE`` para que la
+fase 2 valide el pullback y ejecute la entrada.
 """
 
-# fases/fase1.py – Precandidato Scanner mejorado (30 m near-cross)
-# -----------------------------------------------------------------
-# Selecciona pares USDT que están a punto de cruzar HMA-8 ↑ EMA-24 en 30 m.
-# Coloca el símbolo como "RESERVADA_PRE" para que fase0_precross / phase0_cross15m
-# los vigilen y, si procede, fase2 los compre.
-# -----------------------------------------------------------------
-import asyncio, pandas as pd
-from config import (
-    logger,
-    INITIAL_PRECANDIDATES_LIMIT,
-)
+import asyncio
+from binance.client import Client
+import pandas as pd
+
+from config import logger, PAUSED, SHUTTING_DOWN
 from utils import (
     get_all_usdt_symbols,
     get_historical_data,
     send_telegram_message,
-    check_volume,
-    hull_moving_average,
-    rsi,
+    get_bollinger_bands,
+    get_rsi,
+    get_volume_avg,
 )
-from binance.client import Client
-import config
 
-# ─── parámetros ajustables ─────────────────────────────────────────
-DEBUG_MODE       = False
-MIN_VOLUME_USDT  = 2_000
-MIN_RSI_1H       = 50
-MAX_SPREAD_PCT   = 0.3        # % máximo entre best ask y best bid
-PRECRUCE_MAX_NEG = 0.001      # HMA puede estar hasta −0.1 % por debajo de EMA
+# ----------------------------------------------------------------------
+SCAN_INTERVAL = 900  # segundos
 
-client = config.client  # Binance client global
 
-# ------------------------------------------------------------------
-async def _spread_pct(sym: str) -> float:
-    """Calcula spread % entre oferta y demanda."""
-    try:
-        order_book = await asyncio.to_thread(client.get_order_book, symbol=sym, limit=5)
-        bid = float(order_book["bids"][0][0])
-        ask = float(order_book["asks"][0][0])
-        return 100 * (ask - bid) / bid if bid else 999.0
-    except Exception:
-        return 999.0
-
-# ------------------------------------------------------------------
 async def _is_candidate(sym: str, state: dict) -> bool:
-    if sym in state:
+    """Devuelve True si ``sym`` cumple la ruptura inicial."""
+    rec = state.get(sym)
+    if isinstance(rec, dict) and rec.get("status") in {"COMPRADA", "RESERVADA_PRE"}:
+        return False
+    if isinstance(rec, str) and rec.startswith("RESERVADA_PRE"):
         return False
 
-    # 1) volumen
-    if not await check_volume(sym, MIN_VOLUME_USDT):
+    df = await get_historical_data(sym, Client.KLINE_INTERVAL_4HOUR, 40)
+    if df is None or len(df) < 25:
         return False
 
-    # 2) spread líquido
-    if await _spread_pct(sym) > MAX_SPREAD_PCT:
-        return False
+    close = df["close"].astype(float)
+    volume = df["volume"].astype(float)
 
-    # 3) Historicos 30 m
-    df30 = await get_historical_data(sym, "30m", 120)
-    if df30 is None or len(df30) < 60:
-        return False
-    close30 = df30["close"].astype(float)
-    ema24   = close30.ewm(span=24).mean()
-    hma8    = hull_moving_average(close30, 8)
+    bb_upper, _, _ = get_bollinger_bands(close)
+    rsi_val = get_rsi(close).iloc[-1]
+    vol_avg = get_volume_avg(volume)
 
-    diff    = hma8.iloc[-1] - ema24.iloc[-1]
-    slope   = hma8.diff().iloc[-3:].mean()
+    last_close = close.iloc[-1]
+    last_vol = volume.iloc[-1]
 
-    # HMA por debajo pero muy cerca (<0.1 %) y subiendo
-    if not (diff < 0 and abs(diff)/close30.iloc[-1] <= PRECRUCE_MAX_NEG and slope > 0):
-        return False
+    if last_close > bb_upper.iloc[-1] and last_vol >= 2 * vol_avg and rsi_val > 50:
+        return True
+    return False
 
-    # 4) RSI 1 h > 50 (momentum)
-    df1h = await get_historical_data(sym, Client.KLINE_INTERVAL_1HOUR, 120)
-    if df1h is None or len(df1h) < 30:
-        return False
-    rsi1h_val = rsi(df1h["close"].astype(float), 14).iloc[-1]
-    if rsi1h_val <= MIN_RSI_1H:
-        return False
 
-    # 5) Tendencia 4 h alcista (EMA50 ascendente)
-    df4h = await get_historical_data(sym, Client.KLINE_INTERVAL_4HOUR, 120)
-    if df4h is None or len(df4h) < 30:
-        return False
-    ema50_4h = df4h["close"].astype(float).ewm(span=50).mean()
-    if ema50_4h.diff().iloc[-1] <= 0:
-        return False
-
-    return True
-
-# ------------------------------------------------------------------
 async def phase1_search_20_candidates(state_dict: dict):
-    """Llena el state_dict hasta INITIAL_PRECANDIDATES_LIMIT símbolos."""
-    while len(state_dict) < INITIAL_PRECANDIDATES_LIMIT:
+    """Escanea continuamente en busca de rupturas."""
+    while not SHUTTING_DOWN.is_set():
+        await PAUSED.wait()
         symbols = await get_all_usdt_symbols()
-        selected = []
-        reasons  = [] if DEBUG_MODE else None
+        added: list[str] = []
 
-        async def _eval(sym):
-            ok = await _is_candidate(sym, state_dict)
-            if ok:
-                state_dict[sym] = "RESERVADA_PRE"
-                selected.append(sym)
-            elif DEBUG_MODE:
-                reasons.append(sym)
+        async def _eval(sym: str):
+            try:
+                ok = await _is_candidate(sym, state_dict)
+                if ok:
+                    state_dict[sym] = {"status": "RESERVADA_PRE"}
+                    added.append(sym)
+            except Exception:
+                logger.exception(f"[fase1] error evaluando {sym}")
+
         await asyncio.gather(*[_eval(s) for s in symbols])
 
-        msg = f"Fase 1: añadidos {len(selected)} – total={len(state_dict)}/{INITIAL_PRECANDIDATES_LIMIT}"
-        if selected:
-            msg += "\n" + ", ".join(selected)
-        await send_telegram_message(msg)
-        logger.info(msg)
-
-        if DEBUG_MODE and reasons:
-            await send_telegram_message("Descartados: " + ", ".join(reasons[:30]))
-
-        if len(state_dict) < INITIAL_PRECANDIDATES_LIMIT:
-            await asyncio.sleep(600)  # espera 10 min antes de nuevo ciclo
-
-    done = f"Fase 1 completada con {len(state_dict)} precandidatos."
-    await send_telegram_message(done)
-    logger.info(done)
+        if added:
+            msg = "Fase 1 – nuevas rupturas:\n" + ", ".join(added)
+            await send_telegram_message(msg)
+            logger.info(msg)
+        await asyncio.sleep(SCAN_INTERVAL)

--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -1,42 +1,40 @@
-# fases/fase2.py – Compra tras cruce HMA‑8 ↑ EMA‑24, trailing, PnL real y salida por cruce bajista
-# =================================================================================================
-# Archivo completo. Sustituye tu fases/fase2.py por este contenido.
-"""Fase 2 – ejecución y gestión de operaciones.
+"""Fase 2 – validación de pullback y gestión de posiciones.
 
-Detecta el cruce alcista HMA‑8/EMA‑24, abre una posición y aplica distintos
-métodos de salida: trailing por ATR, Δ‑stop y stop absoluto.  Reporta el PnL real
-o simulado vía Telegram.
+Cada símbolo marcado como ``RESERVADA_PRE`` por la Fase 1 se
+monitorea para detectar un pullback hacia la zona comprendida
+entre la banda superior de Bollinger y la EMA(9).  Si el precio
+rebota desde esa área se ejecuta una compra de mercado.  Las
+posiciones abiertas se cierran si el precio cierra por debajo de
+la EMA(9) o por los stops existentes (trailing ATR, Δ-stop y
+stop absoluto).
 """
 
-import config, asyncio, pandas as pd
+import asyncio
+import config
 from config import PAUSED, SHUTTING_DOWN
-from binance.client import Client
 from binance.helpers import round_step_size
 from binance import exceptions as bexc
 from binance.exceptions import BinanceAPIException
 from config import (
     logger, DRY_RUN, TRAILING_USDT, LIGHT_MODE,
-    EMA_SHORT, EMA_LONG, KLINE_INTERVAL_FASE2, CHECK_INTERVAL,
+    KLINE_INTERVAL_FASE2, CHECK_INTERVAL,
 )
 from utils import (
-    get_historical_data, send_telegram_message, hull_moving_average, rsi,
+    get_historical_data, send_telegram_message,
+    get_bollinger_bands, get_ema,
     get_step_size, atr_stop, trailing_atr_trigger, delta_stop_trigger,
     absolute_stop_trigger,
 )
 from fases.fase3 import phase3_replenish
 
-# ───── Parámetros ────────────────────────────────────────────────────────
-CRUCE_MAX_BARS = 3               # velas máximo desde el cruce para comprar
-SLOPE_BARS     = 2               # barras positivas requeridas en la EMA
-TREND_TF       = Client.KLINE_INTERVAL_2HOUR
-TREND_PERIOD   = 50
-STOP_ATR_MULT  = 1.2             # trailing ATR cuando LIGHT_MODE=False
+# ----------------------------------------------------------------------
+STOP_ATR_MULT = 1.2
 
-# ───── Conversión de comisión a USDT ─────────────────────────────────────
+
 async def _fee_to_usdt(client, fills, quote="USDT") -> float:
     total = 0.0
     for f in fills:
-        comm  = float(f["commission"])
+        comm = float(f["commission"])
         asset = f["commissionAsset"]
         if comm == 0:
             continue
@@ -46,23 +44,14 @@ async def _fee_to_usdt(client, fills, quote="USDT") -> float:
             bnb_price = float((await asyncio.to_thread(
                 client.get_symbol_ticker, symbol="BNBUSDT"))["price"])
             total += comm * bnb_price
-        else:  # asset == base
+        else:
             total += comm * float(f["price"])
     return total
 
-# ───── Helpers técnicos ─────────────────────────────────────────────────
 
-def ema_slope_positive(series: pd.Series, bars=SLOPE_BARS) -> bool:
-    return (series.diff().tail(bars) > 0).all()
-
-# devuelve True si la EMA de mayor tiempo está en tendencia alcista
-def ema_htf_up(close: pd.Series) -> bool:
-    return close.ewm(span=TREND_PERIOD).mean().diff().iloc[-1] > 0
-
-# ───── Market BUY wrapper ───────────────────────────────────────────────
 async def _buy_market(sym, client, usdt, hint_price):
     if DRY_RUN:
-        return dict(qty=usdt/hint_price, price=hint_price,
+        return dict(qty=usdt / hint_price, price=hint_price,
                     entry_cost=usdt, commission=0.0)
     try:
         o = await asyncio.to_thread(
@@ -71,55 +60,48 @@ async def _buy_market(sym, client, usdt, hint_price):
         )
     except BinanceAPIException as e:
         if e.code == -2010:   # balance insuficiente
-            logger.warning(f"{sym}: saldo insuficiente para {usdt} USDT – se descarta")
+            logger.warning(f"{sym}: saldo insuficiente para {usdt} USDT")
             await send_telegram_message(
                 f"⚠️ Sin saldo para comprar {sym}. Ajusta /set entry o recarga USDT."
             )
             return None
-        raise  # otros errores siguen siendo críticos
+        raise
 
-    qty   = float(o["executedQty"])
-    cost  = float(o["cummulativeQuoteQty"])
-    fee   = await _fee_to_usdt(client, o.get("fills", []))
-    price = cost/qty if qty else hint_price
-    return dict(qty=qty, price=price, entry_cost=cost+fee, commission=fee)
-# ───── Evaluador por símbolo ────────────────────────────────────────────
+    qty = float(o["executedQty"])
+    cost = float(o["cummulativeQuoteQty"])
+    fee = await _fee_to_usdt(client, o.get("fills", []))
+    price = cost / qty if qty else hint_price
+    return dict(qty=qty, price=price, entry_cost=cost + fee, commission=fee)
+
+
 async def _evaluate(sym, state, client, freed):
-    """Gestiona entrada y salida individual de ``sym``."""
-
     rec = state.get(sym)
+    status = rec if isinstance(rec, str) else rec.get("status")
 
     # -------- ENTRADA --------
-    if isinstance(rec, str) and rec.startswith("RESERVADA"):
-        df = await get_historical_data(sym, KLINE_INTERVAL_FASE2, 200)
-        if df is None or len(df) < 100:
+    if status == "RESERVADA_PRE":
+        df = await get_historical_data(sym, KLINE_INTERVAL_FASE2, 60)
+        if df is None or len(df) < 30:
             return
         close = df["close"].astype(float)
-        ema24 = close.ewm(span=EMA_LONG).mean()
-        hma8  = hull_moving_average(close, EMA_SHORT)
-        rsi14 = rsi(close, 14)
+        high = df["high"].astype(float)
+        low = df["low"].astype(float)
+        volume = df["volume"].astype(float)
 
-        diff  = hma8 - ema24
-        cross = (diff > 0) & (diff.shift(1) <= 0)
-        if not cross.any():
-            return
-        bars_since = len(df)-1 - df.index.get_loc(cross[cross].index[-1])
-        if bars_since > CRUCE_MAX_BARS:
-            if diff.iloc[-1] > 0:
-                state.pop(sym, None)
-            return
-        if not ema_slope_positive(ema24):
-            return
-        d_htf = await get_historical_data(sym, TREND_TF, 120)
-        if d_htf is None or not ema_htf_up(d_htf["close"]):
-            return
-        if rsi14.iloc[-1] <= 50:
+        bb_upper, _, _ = get_bollinger_bands(close)
+        ema9 = get_ema(close, 9)
+
+        pull_low = low.iloc[-2]
+        in_zone = ema9.iloc[-2] <= pull_low <= bb_upper.iloc[-2]
+        rebound = close.iloc[-1] > close.iloc[-2]
+        if not (in_zone and rebound):
             return
 
         trade = await _buy_market(sym, client, config.MIN_ENTRY_USDT, close.iloc[-1])
-        if trade is None:          # fallo por saldo
-            state.pop(sym, None)   # quita el símbolo y sigue
+        if trade is None:
+            state.pop(sym, None)
             return
+
         state[sym] = dict(
             status="COMPRADA",
             entry_price=trade["price"],
@@ -137,51 +119,43 @@ async def _evaluate(sym, state, client, freed):
         return
 
     # -------- GESTIÓN --------
-    if isinstance(rec, dict) and rec["status"].startswith("COMPRADA"):
+    if isinstance(rec, dict) and rec.get("status", "").startswith("COMPRADA"):
         df = await get_historical_data(sym, KLINE_INTERVAL_FASE2, 12)
         if df is None or df.empty:
             return
         last = float(df["close"].iloc[-1])
         rec["max_price"] = max(rec.get("max_price", rec["entry_price"]), last)
 
-        # Salida por cruce bajista
-        close = df["close"].astype(float)
-        ema24 = close.ewm(span=EMA_LONG).mean()
-        hma8  = hull_moving_average(close, EMA_SHORT)
-        if hma8.iloc[-1] - ema24.iloc[-1] <= 0 and hma8.iloc[-2] - ema24.iloc[-2] > 0:
-            await send_telegram_message(f"🚨 CROSS-EXIT {sym} cruce bajista @ {last:.4f}")
+        ema9 = get_ema(df["close"].astype(float), 9)
+        if last < ema9.iloc[-1]:
+            await send_telegram_message(f"🚨 EMA9-EXIT {sym} @ {last:.4f}")
             freed.append(sym)
 
-        # Trailing ATR
         if not LIGHT_MODE and trailing_atr_trigger(rec, last, TRAILING_USDT):
             await send_telegram_message(f"🚨 STOP {sym} @ {last:.4f}")
             freed.append(sym)
 
-        # Δ-stop
         if delta_stop_trigger(rec, last, config.STOP_DELTA_USDT):
             await send_telegram_message(f"🚨 Δ-STOP {sym} @ {last:.4f}")
             freed.append(sym)
 
-        # stop absoluto
         if absolute_stop_trigger(rec["quantity"], last, config.STOP_ABS_USDT):
             await send_telegram_message(f"🚨 ABS-STOP {sym} @ {last:.4f}")
             freed.append(sym)
 
-        # -------- VENTA --------
-        # -------- VENTA --------
         if sym in freed:
-            if not DRY_RUN:                       # ← venta real
+            if not DRY_RUN:
                 step = await get_step_size(sym)
-                qty  = round_step_size(rec["quantity"], step)
+                qty = round_step_size(rec["quantity"], step)
                 try:
                     sell = await asyncio.to_thread(
                         client.create_order,
                         symbol=sym, side="SELL", type="MARKET", quantity=qty,
                     )
                     value = float(sell.get("cummulativeQuoteQty", 0.0))
-                    fee   = await _fee_to_usdt(client, sell.get("fills", []))
-                    pnl   = value - fee - rec["entry_cost"]
-                    pct   = 100 * pnl / rec["entry_cost"]
+                    fee = await _fee_to_usdt(client, sell.get("fills", []))
+                    pnl = value - fee - rec["entry_cost"]
+                    pct = 100 * pnl / rec["entry_cost"]
 
                     await send_telegram_message(
                         f"💰 VENTA {sym} @ {last:.4f}\n"
@@ -192,13 +166,11 @@ async def _evaluate(sym, state, client, freed):
                     logger.info(f"SELL {sym} pnl={pnl:.4f} pct={pct:.2f}")
                 except bexc.BinanceAPIException as e:
                     logger.error(f"Venta {sym} err: {e}")
-
-            else:                                 # ← simulación
+            else:
                 value = last * rec["quantity"]
-                fee   = 0.0
-                pnl   = value - fee - rec["entry_cost"]
-                pct   = 100 * pnl / rec["entry_cost"]
-
+                fee = 0.0
+                pnl = value - fee - rec["entry_cost"]
+                pct = 100 * pnl / rec["entry_cost"]
                 await send_telegram_message(
                     f"💰 (SIM) VENTA {sym} @ {last:.4f}\n"
                     f"🔻 Valor simulado: {value:.2f} USDT\n"
@@ -206,13 +178,13 @@ async def _evaluate(sym, state, client, freed):
                 )
                 logger.info(f"SIM-SELL {sym} pnl={pnl:.4f} pct={pct:.2f}")
 
-            state.pop(sym, None)                  # ← dentro del bloque 'if sym in freed'
+            state.pop(sym, None)
 
-# ───── Loop principal ────────────────────────────────────────────────────
+
 async def phase2_monitor(state, client, exclusion_dict):
     while True:
-        await PAUSED.wait()                     # ← respeta /pausa
-        if SHUTTING_DOWN.is_set():              # ← sale en /apagar
+        await PAUSED.wait()
+        if SHUTTING_DOWN.is_set():
             break
         freed = []
         try:
@@ -221,7 +193,7 @@ async def phase2_monitor(state, client, exclusion_dict):
             ])
         except Exception:
             logger.exception("[fase2] crash")
-            raise  # supervisor reiniciará
+            raise
 
         if freed:
             await phase3_replenish(state, exclusion_dict, len(freed))

--- a/main.py
+++ b/main.py
@@ -27,8 +27,6 @@ async def supervise(coro_factory, *args):
 from telegram_commands import build_telegram_app
 
 # fases
-from fases.fase0_precross import phase0_precross
-from fases.fase0_cross15m import phase0_cross15m
 from fases.fase1 import phase1_search_20_candidates
 from fases.fase2 import phase2_monitor
 from fases.position_sync import sync_positions
@@ -52,12 +50,9 @@ async def main():
     asyncio.create_task(app.updater.start_polling())
 
     asyncio.create_task(supervise(watch_manual_file, state_dict, exclusion_dict))
-    asyncio.create_task(supervise(phase0_precross, state_dict))
-    asyncio.create_task(supervise(phase0_cross15m, state_dict))
     asyncio.create_task(delayed_sync())
     asyncio.create_task(supervise(phase2_monitor, state_dict, client, exclusion_dict))
-
-    await phase1_search_20_candidates(state_dict)
+    asyncio.create_task(supervise(phase1_search_20_candidates, state_dict))
 
     # Heart-beat
     while not SHUTTING_DOWN.is_set():

--- a/utils_quant.py
+++ b/utils_quant.py
@@ -71,4 +71,5 @@ async def is_quant_candidate(symbol: str) -> bool:
     if df["volume"].iloc[-1] < df["volume"].iloc[-20:-1].mean()*RVOL_MIN:
         return False
     if await aggtrade_delta(symbol) < CVD_MIN:
-        return False    return True
+        return False
+    return True


### PR DESCRIPTION
## Summary
- scan USDT pairs continuously for breakouts
- watch for pullbacks to EMA9 before buying
- manage positions with EMA9 exit and existing trailing stops
- add technical indicator helpers
- adjust main to run new scanning phase
- fix minor typo in utils_quant

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ee43a973c832abdd660a56678d23d