### PR TITLE
Implement candidate slot limits and telegram commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pip install -r requirements.txt
 automático.
 
 Los parámetros pueden modificarse en caliente a través de comandos de Telegram
-(`/set`, `/add`, `/elimina`, `/pausa`, etc.).
+(`/set`, `/add`, `/elimina`, `/pausa`, etc.).  Nuevos comandos útiles:
+`/maxcandidatos`, `/listar` y `/gitpull`.
 
 ### Archivo `manual_candidates.txt`
 

--- a/config.py
+++ b/config.py
@@ -52,6 +52,8 @@ INITIAL_PRECANDIDATES_LIMIT = 5
 MAX_TRACKED_COINS        = 20
 PRECANDIDATES_PER_FREED_COIN = 4
 COOLDOWN_CANDLES         = 2
+# límite de posiciones abiertas simultáneas
+MAX_OPERACIONES_ACTIVAS  = 20
 # EMA / HMA
 EMA_SHORT  = 8
 EMA_LONG   = 24
@@ -95,6 +97,16 @@ def update_min_entry_usdt(new_val: str) -> Optional[str]:
     global MIN_ENTRY_USDT
     try:
         MIN_ENTRY_USDT = float(new_val)
+    except ValueError:
+        return "Debe ser numérico"
+    return None
+
+# ------------- límite dinámico de operaciones activas -------------
+def update_max_operaciones_activas(new_val: str) -> Optional[str]:
+    """Cambia el número máximo de operaciones simultáneas."""
+    global MAX_OPERACIONES_ACTIVAS
+    try:
+        MAX_OPERACIONES_ACTIVAS = int(new_val)
     except ValueError:
         return "Debe ser numérico"
     return None

--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -30,6 +30,12 @@ from fases.fase3 import phase3_replenish
 # ----------------------------------------------------------------------
 STOP_ATR_MULT = 1.2
 
+def _active_positions(state: dict) -> int:
+    return sum(
+        1 for r in state.values()
+        if isinstance(r, dict) and str(r.get("status", "")).startswith("COMPRADA")
+    )
+
 
 async def _fee_to_usdt(client, fills, quote="USDT") -> float:
     total = 0.0
@@ -80,6 +86,8 @@ async def _evaluate(sym, state, client, freed):
 
     # -------- ENTRADA --------
     if status == "RESERVADA_PRE":
+        if _active_positions(state) >= config.MAX_OPERACIONES_ACTIVAS:
+            return
         df = await get_historical_data(sym, KLINE_INTERVAL_FASE2, 60)
         if df is None or len(df) < 30:
             return


### PR DESCRIPTION
## Summary
- add `MAX_OPERACIONES_ACTIVAS` setting and updater
- limit new candidates in `fase1` and new entries in `fase2`
- add telegram commands `/listar`, `/maxcandidatos` and `/gitpull`
- document new commands in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874fe8592b8832a8e3f8e3902ceefba