### PR TITLE
Implement limit check and unify exit msgs

### DIFF
--- a/telegram_commands.py
+++ b/telegram_commands.py
@@ -170,7 +170,10 @@ def build_telegram_app(
 
     # ---------- /listar ----------
     async def listar_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
-        activos = [s for s, r in state_dict.items() if isinstance(r, dict)]
+        activos = [
+            s for s, r in state_dict.items()
+            if isinstance(r, dict) and r.get("status") == "COMPRADA"
+        ]
         lines = [
             f"🎯 {len(activos)}/{config.MAX_OPERACIONES_ACTIVAS} operaciones activas:"
         ]
@@ -277,6 +280,7 @@ def build_telegram_app(
         out = (proc.stdout + proc.stderr).strip()
         if out:
             await update.message.reply_text(f"`{out}`", parse_mode="Markdown")
+        await update.message.reply_text("✅ Repositorio actualizado; reiniciando…")
         await restart_cmd(update, ctx)
 
     # ---------- registro ----------


### PR DESCRIPTION
## Summary
- enforce active position limit and avoid duplicate sells
- unify exit messages for fase2 and sync
- track sold symbols and skip duplicates
- update Telegram commands for listing and git pull

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687922d5929c832aa405899e908b8338