### PR TITLE
Unifica comandos de listado

### DIFF
--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -81,7 +81,7 @@ async def _evaluate(sym, state, client, freed, exclusion_dict):
     # 2.1 Chequeo de límite
     activas = sum(
         1 for rec in state.values()
-        if isinstance(rec, dict) and rec.get("status") == "COMPRADA"
+        if isinstance(rec, dict) and str(rec.get("status", "")).startswith("COMPRADA")
     )
     if activas >= config.MAX_OPERACIONES_ACTIVAS:
         logger.info(


### PR DESCRIPTION
## Summary
- merge `/lista` into `/listar`
- show active positions from bot and synced with origin label
- handle both `COMPRADA` and `COMPRADA_SYNC` statuses
- remove obsolete `/lista` handler

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687995c53bcc832abbe640aa603e0e08