### PR TITLE
Implement new value-based stops

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,12 +34,12 @@ for noisy in ("httpx", "telegram._network.httpx_backend",
 # ───── Parámetros globales del bot ──────────────────────────────────
 DRY_RUN                  = False          # no envía orden real si True
 # tamaños
-MIN_ENTRY_USDT           = 20.0
+MIN_ENTRY_USDT           = 20
 MIN_SYNC_USDT            = 10.0
 # stops
 TRAILING_USDT            = 2.0            # colchón ATR
-STOP_DELTA_USDT          = 1.0            # trailing dinámico (máx-price−Δ)
-STOP_ABS_USDT            = 18.0           # stop absoluto en valor
+STOP_DELTA_USDT          = 1              # trailing fijo en USDT
+STOP_ABS_USDT            = 18             # stop absoluto en USDT
 STOP_ABS_HIGH_FACTOR     = 51.0           # stop por cantidad si precio alto
 STOP_ABS_HIGH_THRESHOLD  = 55.0           # umbral de precio alto USDT
 # modo liviano
@@ -53,7 +53,7 @@ MAX_TRACKED_COINS        = 20
 PRECANDIDATES_PER_FREED_COIN = 4
 COOLDOWN_CANDLES         = 2
 # límite de posiciones abiertas simultáneas
-MAX_OPERACIONES_ACTIVAS  = 20
+MAX_OPERACIONES_ACTIVAS  = 10
 # EMA / HMA
 EMA_SHORT  = 8
 EMA_LONG   = 24


### PR DESCRIPTION
## Summary
- refine configuration defaults
- simplify `update_light_stops` to work with position value
- enforce minimum notional and store value-based fields in phase2
- sync positions and exits using the new stop logic
- show PnL and delta stop in `/listar`
- fix entry cost tracking in sync

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bcc2f12a4832a8469e959d5eb54bb