### PR TITLE
Implement trail stop_delta helper

### DIFF
--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -24,7 +24,7 @@ from utils import (
     get_historical_data, send_telegram_message,
     get_bollinger_bands, get_ema,
     get_step_size, get_market_filters, update_light_stops,
-    safe_market_sell, log_sale_to_excel,
+    trail_stop_delta, safe_market_sell, log_sale_to_excel,
 )
 from fases.fase3 import phase3_replenish
 


### PR DESCRIPTION
## Summary
- add `trail_stop_delta` helper to ensure Δ-stop only moves up
- use helper when updating `stop_delta`
- expose helper from `utils` in `fase2`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d68a9f6f0832ab3846d9e1e282a81