### PR TITLE
Implement cooldown mechanism for sold symbols

### DIFF
--- a/config.py
+++ b/config.py
@@ -55,6 +55,8 @@ COOLDOWN_CANDLES         = 2
 # --- control de saldo insuficiente ---
 INSUFFICIENT_BALANCE_COOLDOWN = 600      # 10 min
 NO_BALANCE_UNTIL = 0.0                   # timestamp; 0 = sin cooldown
+# bloqueo tras venta
+COOLDOWN_HOURS           = 12          # bloqueo post-venta (horas)
 # límite de posiciones abiertas simultáneas
 MAX_OPERACIONES_ACTIVAS  = 10
 # EMA / HMA

--- a/fases/fase1.py
+++ b/fases/fase1.py
@@ -21,6 +21,7 @@ from utils import (
     get_bollinger_bands,
     get_rsi,
     get_volume_avg,
+    cooldown_active,
 )
 
 # ----------------------------------------------------------------------
@@ -62,7 +63,7 @@ async def _is_candidate(sym: str, state: dict) -> bool:
     return False
 
 
-async def phase1_search_20_candidates(state_dict: dict):
+async def phase1_search_20_candidates(state_dict: dict, exclusion_dict: dict):
     """Escanea continuamente en busca de rupturas."""
     await asyncio.sleep(INITIAL_DELAY)  # espera inicial
     while not SHUTTING_DOWN.is_set():
@@ -85,6 +86,8 @@ async def phase1_search_20_candidates(state_dict: dict):
         added: list[str] = []
 
         async def _eval(sym: str):
+            if cooldown_active(exclusion_dict, sym):
+                return
             try:
                 ok = await _is_candidate(sym, state_dict)
                 if ok:

--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -25,6 +25,7 @@ from utils import (
     get_bollinger_bands, get_ema,
     get_step_size, get_market_filters, update_light_stops,
     trail_stop_delta, safe_market_sell, log_sale_to_excel,
+    set_cooldown,
 )
 from fases.fase3 import phase3_replenish
 
@@ -181,10 +182,10 @@ async def _evaluate(sym, state, client, freed, exclusion_dict):
             await send_telegram_message(texto)
             if not DRY_RUN:
                 await log_sale_to_excel(sym, value, pnl, pct)
+                set_cooldown(exclusion_dict, sym, config.COOLDOWN_HOURS)
             logger.info(f"SELL {sym} pnl={pnl:.4f} pct={pct:.2f}")
 
             state.pop(sym, None)
-            exclusion_dict[sym] = True
 
 
 async def phase2_monitor(state, client, exclusion_dict):

--- a/fases/position_sync.py
+++ b/fases/position_sync.py
@@ -20,6 +20,7 @@ from utils import (
     get_all_usdt_symbols, get_step_size, send_telegram_message,
     update_light_stops, get_historical_data, get_ema,
     safe_market_sell, log_sale_to_excel,
+    set_cooldown,
 )
 from fases.fase3 import phase3_search_new_candidates
 
@@ -150,12 +151,12 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
                                     await send_telegram_message(texto)
                                     if not DRY_RUN:
                                         await log_sale_to_excel(symbol, value, pnl, pct)
+                                        set_cooldown(exclusion_dict, symbol, config.COOLDOWN_HOURS)
                                     logger.info(f"SELL {symbol} pnl={pnl:.4f} pct={pct:.2f}")
                                 except Exception:
                                     logger.exception(f"Venta sync {symbol} falló")
 
                             state.pop(symbol, None)
-                            exclusion_dict[symbol] = True
                             await phase3_search_new_candidates(state, _ensure_int(1), exclusion_dict)
                     continue
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ async def main():
     asyncio.create_task(supervise(watch_manual_file, state_dict, exclusion_dict))
     asyncio.create_task(delayed_sync())
     asyncio.create_task(supervise(phase2_monitor, state_dict, client, exclusion_dict))
-    asyncio.create_task(supervise(phase1_search_20_candidates, state_dict))
+    asyncio.create_task(supervise(phase1_search_20_candidates, state_dict, exclusion_dict))
 
     # Heart-beat
     while not SHUTTING_DOWN.is_set():

--- a/utils.py
+++ b/utils.py
@@ -381,3 +381,25 @@ def trail_stop_delta(rec: dict, value_now: float, delta_usdt: float) -> bool:
         rec["stop_delta"] = new_stop
         return True
     return False
+
+
+from datetime import datetime, timedelta
+
+
+def set_cooldown(exclusion_dict: dict, symbol: str, hours: int):
+    """Guarda en exclusion_dict[symbol] un timestamp ISO-8601 indicando
+    hasta cuándo el símbolo queda bloqueado."""
+    until = datetime.utcnow() + timedelta(hours=hours)
+    exclusion_dict[symbol] = until.isoformat()
+
+
+def cooldown_active(exclusion_dict: dict, symbol: str) -> bool:
+    """Devuelve True si el símbolo sigue bloqueado.
+    Limpia la entrada cuando el cooldown ha expirado."""
+    ts = exclusion_dict.get(symbol)
+    if not ts:
+        return False
+    if datetime.utcnow() > datetime.fromisoformat(ts):
+        exclusion_dict.pop(symbol, None)
+        return False
+    return True


### PR DESCRIPTION
## Summary
- add `COOLDOWN_HOURS` constant in `config`
- create `set_cooldown` and `cooldown_active` helpers
- skip cooled-down symbols in phase1 scanning
- record cooldown after real sales in phase2 and position sync
- pass exclusion dict to phase1 in `main`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ed9e02e60832a963f653bf64fcdeb