### PR TITLE
Activa trailing stop tras superar umbral

### DIFF
--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -128,6 +128,7 @@ async def _evaluate(sym, state, client, freed, exclusion_dict):
             "quantity":    trade["qty"],
             "max_value":   trade["entry_cost"],
             "stop_delta":  trade["entry_cost"] - config.STOP_DELTA_USDT,
+            "trailing_active": False,
         }
         await send_telegram_message(
             f"✅ COMPRA {sym} @ {trade['price']:.4f} (Qty {trade['qty']:.4f})\n"

--- a/fases/position_sync.py
+++ b/fases/position_sync.py
@@ -168,6 +168,7 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
                     "quantity":    qty,
                     "max_value":   current_value,
                     "stop_delta":  current_value - config.STOP_DELTA_USDT,
+                    "trailing_active": False,
                 }
                 await send_telegram_message(
                     f"📡 Sincronizada {symbol} • value={current_value:.2f} USDT"

--- a/utils.py
+++ b/utils.py
@@ -229,12 +229,25 @@ def update_light_stops(rec: dict, qty: float, last_price: float,
 
     value_now = qty * last_price
 
-    # inicializar campos faltantes (posiciones legacy)
+    # variable de activación por símbolo
+    active = rec.setdefault("trailing_active", False)
+
+    # activar solo cuando el precio supere entry + stop_delta + 1
+    if not active:
+        activation_price = rec.get("entry_price", 0) + stop_delta_usdt + 1
+        if last_price >= activation_price:
+            rec["trailing_active"] = True
+            rec["max_value"] = value_now
+            rec["stop_delta"] = value_now - stop_delta_usdt
+        else:
+            return False
+
+    # inicializar campos faltantes (posiciones legacy una vez activadas)
     if "max_value" not in rec:
         rec["max_value"] = value_now
     if "stop_delta" not in rec:
         rec["stop_delta"] = rec["max_value"] - stop_delta_usdt
-        return False  # no puede activarse en la primera pasada
+        return False
 
     # trailing Δ-stop
     if value_now > rec["max_value"]:


### PR DESCRIPTION
## Summary
- Activa el trailing stop solo después de que el precio alcance `entry_price + stop_delta + 1`.
- Añade bandera `trailing_active` por símbolo para gestionar la activación del trailing.
- Aplica la nueva lógica tanto en la fase de compra como en la sincronización de posiciones.

## Testing
- `python -m py_compile utils.py fases/fase2.py fases/position_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a260ada6d8832a83bb07cbf3ccfc0e