### PR TITLE
Delay activation of trailing stop until price threshold

### DIFF
--- a/fases/fase2.py
+++ b/fases/fase2.py
@@ -30,6 +30,12 @@ from utils import (
 from fases.fase3 import phase3_replenish
 
 
+async def send_log_message(msg: str):
+    """Envía un mensaje a Telegram y lo registra en el log."""
+    logger.info(msg)
+    await send_telegram_message(msg)
+
+
 async def _fee_to_usdt(client, fills, quote="USDT") -> float:
     total = 0.0
     for f in fills:
@@ -122,13 +128,14 @@ async def _evaluate(sym, state, client, freed, exclusion_dict):
             return
 
         state[sym] = {
-            "status":      "COMPRADA",
-            "entry_price": trade["price"],
-            "entry_cost":  trade["entry_cost"],
-            "quantity":    trade["qty"],
-            "max_value":   trade["entry_cost"],
-            "stop_delta":  trade["entry_cost"] - config.STOP_DELTA_USDT,
-            "trailing_active": False,
+            "status":           "COMPRADA",
+            "entry_price":      trade["price"],
+            "entry_cost":       trade["entry_cost"],
+            "quantity":         trade["qty"],
+            "max_value":        trade["entry_cost"],
+            "stop_delta":       None,  # aún no se activa
+            "trailing_active":  False,
+            "trailing_trigger": trade["price"] + config.STOP_DELTA_USDT + 1,
         }
         await send_telegram_message(
             f"✅ COMPRA {sym} @ {trade['price']:.4f} (Qty {trade['qty']:.4f})\n"
@@ -146,10 +153,19 @@ async def _evaluate(sym, state, client, freed, exclusion_dict):
         ema9 = get_ema(df["close"].astype(float), 9)
         value_now = rec["quantity"] * last
 
+        if not rec["trailing_active"] and last >= rec["trailing_trigger"]:
+            rec["trailing_active"] = True
+            rec["stop_delta"] = rec["quantity"] * last - config.STOP_DELTA_USDT
+            await send_log_message(
+                f"🔓 Trailing activado para {sym} a partir de {last:.2f}"
+            )
+
         # --- disparadores ---
         if last < ema9.iloc[-1]:
             rec["exit_reason"] = "EMA9-EXIT"; freed.append(sym)
-        elif update_light_stops(rec, rec["quantity"], last, config.STOP_DELTA_USDT):
+        elif rec["trailing_active"] and update_light_stops(
+            rec, rec["quantity"], last, config.STOP_DELTA_USDT
+        ):
             rec["exit_reason"] = "Δ-STOP"; freed.append(sym)
         elif value_now <= config.STOP_ABS_USDT:
             rec["exit_reason"] = "ABS-STOP"; freed.append(sym)


### PR DESCRIPTION
## Summary
- Initialize positions with inactive trailing stop and trigger price
- Activate trailing stop only after price exceeds entry + STOP_DELTA_USDT + 1
- Guard trailing stop updates behind activation flag

## Testing
- `python -m py_compile fases/fase2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5f0d46848832a810a4d7e2db1b144