### PR TITLE
Refactor position state schema

### DIFF
--- a/fases/position_sync.py
+++ b/fases/position_sync.py
@@ -83,6 +83,8 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
                 light_mode      = config.LIGHT_MODE
 
                 rec = state.get(symbol)
+                if isinstance(rec, dict) and "entry_value" in rec and "entry_cost" not in rec:
+                    rec["entry_cost"] = rec.pop("entry_value")
 
                 # -------- posición ya sincronizada --------
                 if rec and isinstance(rec, dict):
@@ -162,14 +164,14 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
 
                 # -------- registrar nueva posición --------
                 state[symbol] = {
-                    "status":      "COMPRADA_SYNC",
-                    "entry_price": price,
-                    "entry_cost":  current_value,
-                    "quantity":    qty,
-                    "max_value":   current_value,
-                    "stop_delta":  current_value - config.STOP_DELTA_USDT,
+                    "status":         "COMPRADA_SYNC",
+                    "entry_price":    price,
+                    "entry_cost":     current_value,
+                    "quantity":       qty,
+                    "max_value":      current_value,
+                    "stop_delta":     None,
                     "trailing_active": False,
-                    "trigger_price": None,
+                    "exit_reason":    None,
                 }
                 await send_telegram_message(
                     f"📡 Sincronizada {symbol} • value={current_value:.2f} USDT"

--- a/telegram_commands.py
+++ b/telegram_commands.py
@@ -153,15 +153,16 @@ def build_telegram_app(
         if activos:
             body.append("💰 Posiciones abiertas:")
             for sym, rec in activos:
-                qty = rec["quantity"]
+                qty = float(rec.get("quantity", 0.0))
                 tkr = await asyncio.to_thread(config.client.get_symbol_ticker, symbol=sym)
                 last = float(tkr["price"])
-                pnl = last * qty - rec["entry_cost"]
-                pct = 100 * pnl / rec["entry_cost"]
-                body.append(
-                    f"{sym}: PnL={pnl:+.2f}\u202F({pct:+.2f}\u202F%) | "
-                    f"Δ-stop={rec['stop_delta']:.2f}"
-                )
+                entry_cost = float(rec.get("entry_cost", 0.0))
+                pnl = last * qty - entry_cost
+                pct = 100 * pnl / entry_cost if entry_cost > 0 else 0.0
+                delta = rec.get("stop_delta")
+                delta_txt = f"{delta:.2f}" if isinstance(delta, (int, float)) else "—"
+                line = f"{sym}: PnL={pnl:+.2f}\u202F({pct:+.2f}\u202F%) | Δ-stop={delta_txt}"
+                body.append(line)
 
         if reservadas:
             body.append("\n⏳ Reservadas:")


### PR DESCRIPTION
## Summary
- ensure position_sync records canonical state without enabling stop
- normalize trailing stop handling in fase2 and respect exit reasons
- harden /listar against missing data and drop legacy trigger fields

## Testing
- `python -m py_compile fases/position_sync.py fases/fase2.py telegram_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68a67025b1c4832a9bc7e2de2de0b687