### PR TITLE
Robust cooldown and USDT trailing stop

### DIFF
--- a/fases/fase3.py
+++ b/fases/fase3.py
@@ -12,6 +12,7 @@ from config import (
 from utils import (
     get_all_usdt_symbols,
     send_telegram_message,
+    set_cooldown,
 )
 from fases.fase1 import _is_candidate   # reutilizamos la función
 
@@ -40,7 +41,7 @@ async def phase3_replenish(state_dict: dict,
         if ok:
             state_dict[sym] = "RESERVADA_PRE"
             added.append(sym)
-            exclusion_dict[sym] = {"ts": asyncio.get_event_loop().time()}
+            set_cooldown(exclusion_dict, sym, 10)
 
     await asyncio.gather(*[_eval(s) for s in symbols[:200]])  # solo top 200
 

--- a/fases/position_sync.py
+++ b/fases/position_sync.py
@@ -22,6 +22,9 @@ from utils import (
     safe_market_sell, log_sale_to_excel,
     set_cooldown,
 )
+async def send_log_message(msg: str):
+    logger.info(msg)
+    await send_telegram_message(msg)
 from fases.fase3 import phase3_search_new_candidates
 
 _BIN_SEM = asyncio.Semaphore(3)
@@ -121,7 +124,9 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
                                             logger.warning(f"Venta sync {symbol} falló: {sell}")
                                             await send_telegram_message(f"⚠️ Venta {symbol} cancelada: {sell}")
                                             state.pop(symbol, None)
-                                            exclusion_dict[symbol] = True
+                                            set_cooldown(
+                                                exclusion_dict, symbol, config.COOLDOWN_HOURS * 60
+                                            )
                                             continue
                                         value = float(sell.get("cummulativeQuoteQty", 0.0))
                                         fee = 0.0
@@ -153,7 +158,9 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
                                     await send_telegram_message(texto)
                                     if not DRY_RUN:
                                         await log_sale_to_excel(symbol, value, pnl, pct)
-                                        set_cooldown(exclusion_dict, symbol, config.COOLDOWN_HOURS)
+                                        set_cooldown(
+                                            exclusion_dict, symbol, config.COOLDOWN_HOURS * 60
+                                        )
                                     logger.info(f"SELL {symbol} pnl={pnl:.4f} pct={pct:.2f}")
                                 except Exception:
                                     logger.exception(f"Venta sync {symbol} falló")
@@ -164,18 +171,35 @@ async def sync_positions(state: dict, client, exclusion_dict: dict, interval: in
 
                 # -------- registrar nueva posición --------
                 state[symbol] = {
-                    "status":         "COMPRADA_SYNC",
-                    "entry_price":    price,
-                    "entry_cost":     current_value,
-                    "quantity":       qty,
-                    "max_value":      current_value,
-                    "stop_delta":     None,
+                    "status":          "COMPRADA_SYNC",
+                    "entry_price":     price,
+                    "entry_cost":      current_value,
+                    "quantity":        qty,
+                    "max_value":       current_value,
                     "trailing_active": False,
-                    "exit_reason":    None,
+                    "stop_delta":      None,
+                    "exit_reason":     None,
                 }
                 await send_telegram_message(
                     f"📡 Sincronizada {symbol} • value={current_value:.2f} USDT"
                 )
+                rec = state[symbol]
+                if "entry_value" in rec and "entry_cost" not in rec:
+                    rec["entry_cost"] = rec.pop("entry_value")
+
+                activation_value = rec["entry_cost"] + config.STOP_DELTA_USDT + 1.0
+                if current_value >= activation_value:
+                    base_stop = rec["entry_cost"] + 1.0
+                    first_stop = max(base_stop, current_value - config.STOP_DELTA_USDT)
+                    rec["trailing_active"] = True
+                    rec["max_value"] = current_value
+                    rec["stop_delta"] = first_stop
+                    try:
+                        await send_log_message(
+                            f"📡 Trailing activado (sync) {symbol}: value={current_value:.2f} • stop={first_stop:.2f}"
+                        )
+                    except Exception:
+                        pass
         except Exception:
             logger.exception("[sync] crash")
 

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ import telegram.error
 from binance import exceptions as bexc
 from binance.client import Client
 import math
+from datetime import datetime, timedelta, timezone
 from config import (
     client, logger, telegram_bot, TELEGRAM_CHAT_ID,
     STOP_ABS_HIGH_FACTOR, STOP_ABS_HIGH_THRESHOLD,
@@ -228,32 +229,29 @@ def update_light_stops(rec: dict, qty: float, last_price: float,
     """Actualiza el trailing Δ-stop y devuelve ``True`` si se activa."""
 
     value_now = qty * last_price
-
-    # variable de activación por símbolo
     active = rec.setdefault("trailing_active", False)
+    entry_cost = float(rec.get("entry_cost", rec.get("entry_value", 0.0)))
 
-    # activar solo cuando el precio supere entry + stop_delta + 1
+    # activar solo cuando el valor supere entry_cost + stop_delta + 1
     if not active:
-        activation_price = rec.get("entry_price", 0) + stop_delta_usdt + 1
-        if last_price >= activation_price:
+        activation_value = entry_cost + stop_delta_usdt + 1.0
+        if value_now >= activation_value:
             rec["trailing_active"] = True
             rec["max_value"] = value_now
-            rec["stop_delta"] = value_now - stop_delta_usdt
+            base_stop = entry_cost + 1.0
+            rec["stop_delta"] = max(base_stop, value_now - stop_delta_usdt)
         else:
             return False
 
-    # inicializar campos faltantes (posiciones legacy una vez activadas)
     if "max_value" not in rec:
         rec["max_value"] = value_now
-    if "stop_delta" not in rec:
+    if "stop_delta" not in rec or rec["stop_delta"] is None:
         rec["stop_delta"] = rec["max_value"] - stop_delta_usdt
         return False
 
-    # trailing Δ-stop
     if value_now > rec["max_value"]:
         rec["max_value"] = value_now
-        # trailing Δ-stop sólo sube
-        trail_stop_delta(rec, value_now, stop_delta_usdt)
+        rec["stop_delta"] = max(rec["stop_delta"], value_now - stop_delta_usdt)
 
     return value_now <= rec["stop_delta"]
 
@@ -396,23 +394,60 @@ def trail_stop_delta(rec: dict, value_now: float, delta_usdt: float) -> bool:
     return False
 
 
-from datetime import datetime, timedelta
+def _parse_expiry_any(ts):
+    """
+    Acepta:
+      - str ISO8601 (con o sin 'Z')
+      - datetime (naive o con tz)
+      - epoch (int/float, segundos)
+    Devuelve datetime UTC naive o None si no se puede parsear.
+    """
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        return (
+            ts if ts.tzinfo is None
+            else ts.astimezone(timezone.utc).replace(tzinfo=None)
+        )
+    if isinstance(ts, (int, float)):
+        return datetime.utcfromtimestamp(ts)
+    if isinstance(ts, str):
+        s = ts.strip()
+        try:
+            if s.endswith("Z"):
+                s = s[:-1]
+            dt = datetime.fromisoformat(s)
+            return (
+                dt if dt.tzinfo is None
+                else dt.astimezone(timezone.utc).replace(tzinfo=None)
+            )
+        except Exception:
+            return None
+    return None
 
 
-def set_cooldown(exclusion_dict: dict, symbol: str, hours: int):
-    """Guarda en exclusion_dict[symbol] un timestamp ISO-8601 indicando
-    hasta cuándo el símbolo queda bloqueado."""
-    until = datetime.utcnow() + timedelta(hours=hours)
-    exclusion_dict[symbol] = until.isoformat()
+def set_cooldown(exclusion_dict: dict, sym: str, minutes: int) -> str:
+    """
+    Fija cooldown en ISO8601 (UTC). Centraliza el formato para evitar mezcla de tipos.
+    """
+    expiry = (datetime.utcnow() + timedelta(minutes=minutes)).isoformat()
+    exclusion_dict[sym] = expiry
+    return expiry
 
 
-def cooldown_active(exclusion_dict: dict, symbol: str) -> bool:
-    """Devuelve True si el símbolo sigue bloqueado.
-    Limpia la entrada cuando el cooldown ha expirado."""
-    ts = exclusion_dict.get(symbol)
+def cooldown_active(exclusion_dict: dict, sym: str) -> bool:
+    """
+    True si el símbolo sigue en cooldown.
+    Si ya expiró o el valor es inválido, limpia la entrada y devuelve False.
+    """
+    ts = exclusion_dict.get(sym)
     if not ts:
         return False
-    if datetime.utcnow() > datetime.fromisoformat(ts):
-        exclusion_dict.pop(symbol, None)
+    expires = _parse_expiry_any(ts)
+    if expires is None:
+        exclusion_dict.pop(sym, None)
+        return False
+    if datetime.utcnow() > expires:
+        exclusion_dict.pop(sym, None)
         return False
     return True


### PR DESCRIPTION
## Summary
- Harden cooldown handling with flexible timestamp parsing and standardized ISO storage
- Implement USDT-based trailing stop with delayed activation and monotonic stop updates
- Sync positions with immediate trailing activation when already above threshold

## Testing
- `python -m py_compile utils.py fases/fase2.py fases/fase3.py fases/position_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7c4f308d4832aafdf24f53ba8b814